### PR TITLE
Fix style

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -5,7 +5,7 @@ export default function Header() {
   const [open, setOpen] = useState(false)
 
   return (
-    <nav className="rounded border-gray-200 bg-white px-2 py-2.5 dark:bg-gray-900 sm:px-4">
+    <nav className="rounded border-gray-200 bg-white px-2 py-2.5 sm:px-4">
       <div className="container mx-auto flex flex-wrap items-center justify-between">
         <Link href="/" className="flex items-center">
           <h1 className="text-4xl font-bold leading-tight tracking-tighter md:pr-8 md:text-8xl">K Squad</h1>
@@ -13,7 +13,7 @@ export default function Header() {
         <button
           onClick={() => setOpen(!open)}
           type="button"
-          className="ml-3 inline-flex items-center rounded-lg p-2  text-sm focus:outline-none focus:ring-gray-200  dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600 md:hidden"
+          className="ml-3 inline-flex items-center rounded-lg p-2 text-sm focus:outline-none focus:ring-gray-200 md:hidden"
         >
           <span className="sr-only">Open main menu</span>
           <svg
@@ -34,11 +34,11 @@ export default function Header() {
           className={`${open ? "" : "hidden md:inline-block"} w-full md:w-auto lg:order-1 lg:w-auto`}
           id="mobile-navbar"
         >
-          <ul className="mt-4 flex flex-col rounded-lg p-4 dark:border-gray-700 dark:bg-gray-800 md:mt-0 md:flex-row md:space-x-8 md:border-0 md:bg-white md:text-sm md:font-medium md:dark:bg-gray-900">
+          <ul className="mt-4 flex flex-col rounded-lg p-4 md:mt-0 md:flex-row md:space-x-8 md:border-0 md:bg-white md:text-sm md:font-medium">
             <li>
               <Link
                 href="/company"
-                className="block rounded py-2 pl-3 pr-4 text-xl text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white md:border-0 md:p-0 md:hover:bg-transparent md:dark:hover:bg-transparent md:dark:hover:text-white"
+                className="block rounded py-2 pl-3 pr-4 text-xl text-gray-700 md:border-0 md:p-0 md:hover:bg-transparent"
               >
                 Company
               </Link>
@@ -46,7 +46,7 @@ export default function Header() {
             <li>
               <Link
                 href="/news"
-                className="block rounded py-2 pl-3 pr-4 text-xl text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white md:border-0 md:p-0 md:hover:bg-transparent md:dark:hover:bg-transparent md:dark:hover:text-white"
+                className="block rounded py-2 pl-3 pr-4 text-xl text-gray-700 md:border-0 md:p-0 md:hover:bg-transparent"
               >
                 News
               </Link>
@@ -54,7 +54,7 @@ export default function Header() {
             <li>
               <Link
                 href="/blog"
-                className="block rounded py-2 pl-3 pr-4 text-xl text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white md:border-0 md:p-0 md:hover:bg-transparent md:dark:hover:bg-transparent md:dark:hover:text-white"
+                className="block rounded py-2 pl-3 pr-4 text-xl text-gray-700 md:border-0 md:p-0 md:hover:bg-transparent"
               >
                 Blog
               </Link>
@@ -62,7 +62,7 @@ export default function Header() {
             <li>
               <Link
                 href="/careers"
-                className="block rounded py-2 pl-3 pr-4 text-xl text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white md:border-0 md:p-0 md:hover:bg-transparent md:dark:hover:bg-transparent md:dark:hover:text-white"
+                className="block rounded py-2 pl-3 pr-4 text-xl text-gray-700 md:border-0 md:p-0 md:hover:bg-transparent"
               >
                 Careers
               </Link>
@@ -70,7 +70,7 @@ export default function Header() {
             <li>
               <Link
                 href="/contact"
-                className="block rounded py-2 pl-3 pr-4 text-xl text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white md:border-0 md:p-0 md:hover:bg-transparent md:dark:hover:bg-transparent md:dark:hover:text-white"
+                className="block rounded py-2 pl-3 pr-4 text-xl text-gray-700 md:border-0 md:p-0 md:hover:bg-transparent"
               >
                 Contact
               </Link>

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -9,12 +9,12 @@ type Props = {
 
 const Layout = ({ pageTitle, children }: Props) => {
   return (
-    <>
+    <div className="flex min-h-screen flex-col">
       <Meta pageTitle={pageTitle} />
       <Header />
-      <main>{children}</main>
+      <main className="flex-1">{children}</main>
       <Footer />
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
- 端末の外観モードに依存せず同じ表示をするように変更
- mainがスクリーンサイズ以下の時footerをページの最下部に表示

### before

![image](https://user-images.githubusercontent.com/38322494/213358104-6c3b7b3f-181f-4d6b-b732-c6fe31d4c4bd.png)

### after

![image](https://user-images.githubusercontent.com/38322494/213359771-ac0cefbc-da74-4d5d-807e-675751e5fce0.png)
