### PR TITLE
メンバーのブログを収集するスクリプト

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ pnpm-debug.log*
 
 # asdf
 !.tool-versions
+
+# the directory which contains members blog datas (by feedsCollector)
+.contents

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@astrojs/sitemap": "^1.0.0",
     "@astrojs/tailwind": "^3.0.0",
     "astro": "^2.0.1",
+    "fs-extra": "^11.1.1",
     "preact": "^10.11.3",
     "sharp": "^0.31.3",
     "tailwindcss": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "astro": "^2.0.1",
     "fs-extra": "^11.1.1",
     "preact": "^10.11.3",
+    "rss-parser": "^3.12.0",
     "sharp": "^0.31.3",
     "tailwindcss": "^3.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "@astrojs/sitemap": "^1.0.0",
     "@astrojs/tailwind": "^3.0.0",
     "astro": "^2.0.1",
-    "fs-extra": "^11.1.1",
     "preact": "^10.11.3",
     "rss-parser": "^3.12.0",
     "sharp": "^0.31.3",
     "tailwindcss": "^3.2.4"
   },
   "devDependencies": {
+    "@types/fs-extra": "^11.0.1",
     "@types/node": "^18.11.18",
     "prettier": "^2.8.3",
     "prettier-plugin-astro": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",
+    "collect_rss": "ts-node --project tsconfig.feedsBuilder.json ./src/feedsBuilder/posts.ts",
     "preview": "astro preview",
     "check": "astro check && tsc --noEmit",
     "astro": "astro",
@@ -26,16 +27,18 @@
     "@astrojs/tailwind": "^3.0.0",
     "astro": "^2.0.1",
     "preact": "^10.11.3",
-    "rss-parser": "^3.12.0",
     "sharp": "^0.31.3",
     "tailwindcss": "^3.2.4"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.1",
     "@types/node": "^18.11.18",
+    "fs-extra": "^11.1.1",
     "prettier": "^2.8.3",
     "prettier-plugin-astro": "^0.8.0",
     "prettier-plugin-tailwindcss": "^0.2.2",
+    "rss-parser": "^3.12.0",
+    "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",
-    "collect_rss": "ts-node --project tsconfig.feedsBuilder.json ./src/feedsBuilder/posts.ts",
+    "collect_rss": "ts-node --project tsconfig.feedsCollector.json ./src/feedsCollector/collect.ts",
     "preview": "astro preview",
     "check": "astro check && tsc --noEmit",
     "astro": "astro",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ specifiers:
   '@astrojs/tailwind': ^3.0.0
   '@types/node': ^18.11.18
   astro: ^2.0.1
+  fs-extra: ^11.1.1
   preact: ^10.11.3
   prettier: ^2.8.3
   prettier-plugin-astro: ^0.8.0
@@ -27,6 +28,7 @@ dependencies:
   '@astrojs/sitemap': 1.0.0
   '@astrojs/tailwind': 3.0.0_bgk6wvini4j5nfa7w2itosrqne
   astro: 2.0.1_@types+node@18.11.18
+  fs-extra: 11.1.1
   preact: 10.11.3
   sharp: 0.31.3
   tailwindcss: 3.2.4_postcss@8.4.21
@@ -1765,6 +1767,15 @@ packages:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
     dev: false
 
+  /fs-extra/11.1.1:
+    resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
+    engines: {node: '>=14.14'}
+    dependencies:
+      graceful-fs: 4.2.10
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: false
+
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: false
@@ -2172,6 +2183,14 @@ packages:
 
   /jsonc-parser/3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+    dev: false
+
+  /jsonfile/6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+    dependencies:
+      universalify: 2.0.0
+    optionalDependencies:
+      graceful-fs: 4.2.10
     dev: false
 
   /kind-of/6.0.3:
@@ -3998,6 +4017,11 @@ packages:
       '@types/unist': 2.0.6
       unist-util-is: 5.2.0
       unist-util-visit-parents: 5.1.3
+    dev: false
+
+  /universalify/2.0.0:
+    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
+    engines: {node: '>= 10.0.0'}
     dev: false
 
   /update-browserslist-db/1.0.10_browserslist@4.21.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ specifiers:
   '@astrojs/rss': ^2.1.0
   '@astrojs/sitemap': ^1.0.0
   '@astrojs/tailwind': ^3.0.0
+  '@types/fs-extra': ^11.0.1
   '@types/node': ^18.11.18
   astro: ^2.0.1
-  fs-extra: ^11.1.1
   preact: ^10.11.3
   prettier: ^2.8.3
   prettier-plugin-astro: ^0.8.0
@@ -29,13 +29,13 @@ dependencies:
   '@astrojs/sitemap': 1.0.0
   '@astrojs/tailwind': 3.0.0_bgk6wvini4j5nfa7w2itosrqne
   astro: 2.0.1_@types+node@18.11.18
-  fs-extra: 11.1.1
   preact: 10.11.3
   rss-parser: 3.12.0
   sharp: 0.31.3
   tailwindcss: 3.2.4_postcss@8.4.21
 
 devDependencies:
+  '@types/fs-extra': 11.0.1
   '@types/node': 18.11.18
   prettier: 2.8.3
   prettier-plugin-astro: 0.8.0
@@ -890,6 +890,13 @@ packages:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
     dev: false
 
+  /@types/fs-extra/11.0.1:
+    resolution: {integrity: sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==}
+    dependencies:
+      '@types/jsonfile': 6.1.1
+      '@types/node': 18.11.18
+    dev: true
+
   /@types/hast/2.3.4:
     resolution: {integrity: sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==}
     dependencies:
@@ -899,6 +906,12 @@ packages:
   /@types/json5/0.0.30:
     resolution: {integrity: sha512-sqm9g7mHlPY/43fcSNrCYfOeX9zkTTK+euO5E6+CVijSMm5tTjkVdwdqRkY3ljjIAf8679vps5jKUoJBCLsMDA==}
     dev: false
+
+  /@types/jsonfile/6.1.1:
+    resolution: {integrity: sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==}
+    dependencies:
+      '@types/node': 18.11.18
+    dev: true
 
   /@types/mdast/3.0.10:
     resolution: {integrity: sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==}
@@ -1773,15 +1786,6 @@ packages:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
     dev: false
 
-  /fs-extra/11.1.1:
-    resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
-    engines: {node: '>=14.14'}
-    dependencies:
-      graceful-fs: 4.2.10
-      jsonfile: 6.1.0
-      universalify: 2.0.0
-    dev: false
-
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: false
@@ -2189,14 +2193,6 @@ packages:
 
   /jsonc-parser/3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
-    dev: false
-
-  /jsonfile/6.1.0:
-    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
-    dependencies:
-      universalify: 2.0.0
-    optionalDependencies:
-      graceful-fs: 4.2.10
     dev: false
 
   /kind-of/6.0.3:
@@ -4030,11 +4026,6 @@ packages:
       '@types/unist': 2.0.6
       unist-util-is: 5.2.0
       unist-util-visit-parents: 5.1.3
-    dev: false
-
-  /universalify/2.0.0:
-    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
-    engines: {node: '>= 10.0.0'}
     dev: false
 
   /update-browserslist-db/1.0.10_browserslist@4.21.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ specifiers:
   '@types/fs-extra': ^11.0.1
   '@types/node': ^18.11.18
   astro: ^2.0.1
+  fs-extra: ^11.1.1
   preact: ^10.11.3
   prettier: ^2.8.3
   prettier-plugin-astro: ^0.8.0
@@ -18,6 +19,7 @@ specifiers:
   rss-parser: ^3.12.0
   sharp: ^0.31.3
   tailwindcss: ^3.2.4
+  ts-node: ^10.9.1
   typescript: ^4.9.4
 
 dependencies:
@@ -27,19 +29,21 @@ dependencies:
   '@astrojs/preact': 2.0.0_preact@10.11.3
   '@astrojs/rss': 2.1.0
   '@astrojs/sitemap': 1.0.0
-  '@astrojs/tailwind': 3.0.0_bgk6wvini4j5nfa7w2itosrqne
+  '@astrojs/tailwind': 3.0.0_wqmg6tpxhzmhmydqbmwwmbet34
   astro: 2.0.1_@types+node@18.11.18
   preact: 10.11.3
-  rss-parser: 3.12.0
   sharp: 0.31.3
-  tailwindcss: 3.2.4_postcss@8.4.21
+  tailwindcss: 3.2.4_aesdjsunmf4wiehhujt67my7tu
 
 devDependencies:
   '@types/fs-extra': 11.0.1
   '@types/node': 18.11.18
+  fs-extra: 11.1.1
   prettier: 2.8.3
   prettier-plugin-astro: 0.8.0
   prettier-plugin-tailwindcss: 0.2.2_s2resyd53c3nawyksvkzb3naxm
+  rss-parser: 3.12.0
+  ts-node: 10.9.1_awa2wsr5thmg3i7jqycphctjfq
   typescript: 4.9.4
 
 packages:
@@ -210,7 +214,7 @@ packages:
       zod: 3.20.2
     dev: false
 
-  /@astrojs/tailwind/3.0.0_bgk6wvini4j5nfa7w2itosrqne:
+  /@astrojs/tailwind/3.0.0_wqmg6tpxhzmhmydqbmwwmbet34:
     resolution: {integrity: sha512-Ul0LzTIW+QD/qXUaTDSDoe/uNOPSAX6Ce7yTMzl7v+9OlZ4vlgkj1CUq/WkhlKnJ2+SnJvLArEj6yYs/M2V8nA==}
     peerDependencies:
       astro: ^2.0.0
@@ -220,8 +224,8 @@ packages:
       astro: 2.0.1_@types+node@18.11.18
       autoprefixer: 10.4.13_postcss@8.4.21
       postcss: 8.4.21
-      postcss-load-config: 4.0.1_postcss@8.4.21
-      tailwindcss: 3.2.4_postcss@8.4.21
+      postcss-load-config: 4.0.1_aesdjsunmf4wiehhujt67my7tu
+      tailwindcss: 3.2.4_aesdjsunmf4wiehhujt67my7tu
     transitivePeerDependencies:
       - ts-node
     dev: false
@@ -478,6 +482,12 @@ packages:
       to-fast-properties: 2.0.0
     dev: false
 
+  /@cspotcode/source-map-support/0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   /@emmetio/abbreviation/2.2.3:
     resolution: {integrity: sha512-87pltuCPt99aL+y9xS6GPZ+Wmmyhll2WXH73gG/xpGcQ84DRnptBsI2r0BeIQ0EB/SQTOe2ANPqFqj3Rj5FOGA==}
     dependencies:
@@ -712,7 +722,6 @@ packages:
   /@jridgewell/resolve-uri/3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
     engines: {node: '>=6.0.0'}
-    dev: false
 
   /@jridgewell/set-array/1.1.2:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
@@ -721,7 +730,6 @@ packages:
 
   /@jridgewell/sourcemap-codec/1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
-    dev: false
 
   /@jridgewell/trace-mapping/0.3.17:
     resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
@@ -729,6 +737,12 @@ packages:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: false
+
+  /@jridgewell/trace-mapping/0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
 
   /@ljharb/has-package-exports-patterns/0.0.2:
     resolution: {integrity: sha512-4/RWEeXDO6bocPONheFe6gX/oQdP/bEpv0oL4HqjPP5DCenBSt0mHgahppY49N0CpsaqffdwPq+TlX9CYOq2Dw==}
@@ -838,6 +852,18 @@ packages:
       picomatch: 2.3.1
       rollup: 3.10.1
     dev: false
+
+  /@tsconfig/node10/1.0.9:
+    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
+
+  /@tsconfig/node12/1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  /@tsconfig/node14/1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  /@tsconfig/node16/1.0.3:
+    resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
 
   /@types/acorn/4.0.6:
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
@@ -997,6 +1023,10 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: false
 
+  /acorn-walk/8.2.0:
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
+    engines: {node: '>=0.4.0'}
+
   /acorn/7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
     engines: {node: '>=0.4.0'}
@@ -1007,7 +1037,6 @@ packages:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: false
 
   /ansi-align/3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -1051,6 +1080,9 @@ packages:
       normalize-path: 3.0.0
       picomatch: 2.3.1
     dev: false
+
+  /arg/4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   /arg/5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -1417,6 +1449,9 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /create-require/1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
   /cross-spawn/7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
@@ -1513,6 +1548,10 @@ packages:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
     dev: false
 
+  /diff/4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+
   /diff/5.1.0:
     resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
     engines: {node: '>=0.3.1'}
@@ -1558,7 +1597,7 @@ packages:
 
   /entities/2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
-    dev: false
+    dev: true
 
   /es-module-lexer/0.10.5:
     resolution: {integrity: sha512-+7IwY/kiGAacQfY+YBhKMvEmyAJnw5grTUgjG85Pe7vcUI/6b7pZjZG8nQ7+48YhzEAEqrEgD2dCz/JIK+AYvw==}
@@ -1786,6 +1825,15 @@ packages:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
     dev: false
 
+  /fs-extra/11.1.1:
+    resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
+    engines: {node: '>=14.14'}
+    dependencies:
+      graceful-fs: 4.2.10
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
+
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: false
@@ -1862,7 +1910,6 @@ packages:
 
   /graceful-fs/4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
-    dev: false
 
   /gray-matter/4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
@@ -2195,6 +2242,14 @@ packages:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
     dev: false
 
+  /jsonfile/6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+    dependencies:
+      universalify: 2.0.0
+    optionalDependencies:
+      graceful-fs: 4.2.10
+    dev: true
+
   /kind-of/6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
@@ -2278,6 +2333,9 @@ packages:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: false
+
+  /make-error/1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   /markdown-extensions/1.1.1:
     resolution: {integrity: sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==}
@@ -3127,7 +3185,7 @@ packages:
       postcss: 8.4.21
     dev: false
 
-  /postcss-load-config/3.1.4_postcss@8.4.21:
+  /postcss-load-config/3.1.4_aesdjsunmf4wiehhujt67my7tu:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -3141,10 +3199,11 @@ packages:
     dependencies:
       lilconfig: 2.0.6
       postcss: 8.4.21
+      ts-node: 10.9.1_awa2wsr5thmg3i7jqycphctjfq
       yaml: 1.10.2
     dev: false
 
-  /postcss-load-config/4.0.1_postcss@8.4.21:
+  /postcss-load-config/4.0.1_aesdjsunmf4wiehhujt67my7tu:
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -3158,6 +3217,7 @@ packages:
     dependencies:
       lilconfig: 2.0.6
       postcss: 8.4.21
+      ts-node: 10.9.1_awa2wsr5thmg3i7jqycphctjfq
       yaml: 2.2.1
     dev: false
 
@@ -3552,7 +3612,7 @@ packages:
     dependencies:
       entities: 2.2.0
       xml2js: 0.4.23
-    dev: false
+    dev: true
 
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -3581,7 +3641,6 @@ packages:
 
   /sax/1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
-    dev: false
 
   /section-matter/1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
@@ -3823,7 +3882,7 @@ packages:
       '@pkgr/utils': 2.3.1
       tslib: 2.4.1
 
-  /tailwindcss/3.2.4_postcss@8.4.21:
+  /tailwindcss/3.2.4_aesdjsunmf4wiehhujt67my7tu:
     resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -3847,7 +3906,7 @@ packages:
       postcss: 8.4.21
       postcss-import: 14.1.0_postcss@8.4.21
       postcss-js: 4.0.0_postcss@8.4.21
-      postcss-load-config: 3.1.4_postcss@8.4.21
+      postcss-load-config: 3.1.4_aesdjsunmf4wiehhujt67my7tu
       postcss-nested: 6.0.0_postcss@8.4.21
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
@@ -3902,6 +3961,36 @@ packages:
   /trough/2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
     dev: false
+
+  /ts-node/10.9.1_awa2wsr5thmg3i7jqycphctjfq:
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 18.11.18
+      acorn: 8.8.2
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.9.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
 
   /tsconfig-resolver/3.0.1:
     resolution: {integrity: sha512-ZHqlstlQF449v8glscGRXzL6l2dZvASPCdXJRWG4gHEZlUVx2Jtmr+a2zeVG4LCsKhDXKRj5R3h0C/98UcVAQg==}
@@ -4028,6 +4117,11 @@ packages:
       unist-util-visit-parents: 5.1.3
     dev: false
 
+  /universalify/2.0.0:
+    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
+    engines: {node: '>= 10.0.0'}
+    dev: true
+
   /update-browserslist-db/1.0.10_browserslist@4.21.4:
     resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
     hasBin: true
@@ -4053,6 +4147,9 @@ packages:
       kleur: 4.1.5
       sade: 1.8.1
     dev: false
+
+  /v8-compile-cache-lib/3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   /vfile-location/4.0.1:
     resolution: {integrity: sha512-JDxPlTbZrZCQXogGheBHjbRWjESSPEak770XwWPfw5mTc1v1nWGLB/apzZxsx8a0SJVfF8HK8ql8RD308vXRUw==}
@@ -4239,12 +4336,12 @@ packages:
     dependencies:
       sax: 1.2.4
       xmlbuilder: 11.0.1
-    dev: false
+    dev: true
 
   /xmlbuilder/11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
-    dev: false
+    dev: true
 
   /xtend/4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -4273,6 +4370,10 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
     dev: false
+
+  /yn/3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
 
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ specifiers:
   prettier: ^2.8.3
   prettier-plugin-astro: ^0.8.0
   prettier-plugin-tailwindcss: ^0.2.2
+  rss-parser: ^3.12.0
   sharp: ^0.31.3
   tailwindcss: ^3.2.4
   typescript: ^4.9.4
@@ -30,6 +31,7 @@ dependencies:
   astro: 2.0.1_@types+node@18.11.18
   fs-extra: 11.1.1
   preact: 10.11.3
+  rss-parser: 3.12.0
   sharp: 0.31.3
   tailwindcss: 3.2.4_postcss@8.4.21
 
@@ -1539,6 +1541,10 @@ packages:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
       once: 1.4.0
+    dev: false
+
+  /entities/2.2.0:
+    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
     dev: false
 
   /es-module-lexer/0.10.5:
@@ -3545,6 +3551,13 @@ packages:
       fsevents: 2.3.2
     dev: false
 
+  /rss-parser/3.12.0:
+    resolution: {integrity: sha512-aqD3E8iavcCdkhVxNDIdg1nkBI17jgqF+9OqPS1orwNaOgySdpvq6B+DoONLhzjzwV8mWg37sb60e4bmLK117A==}
+    dependencies:
+      entities: 2.2.0
+      xml2js: 0.4.23
+    dev: false
+
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -4227,6 +4240,19 @@ packages:
 
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: false
+
+  /xml2js/0.4.23:
+    resolution: {integrity: sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      sax: 1.2.4
+      xmlbuilder: 11.0.1
+    dev: false
+
+  /xmlbuilder/11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
     dev: false
 
   /xtend/4.0.2:

--- a/src/feedsCollector/collect.ts
+++ b/src/feedsCollector/collect.ts
@@ -1,0 +1,83 @@
+import fs from "fs-extra";
+import Parser from "rss-parser";
+import { members } from "./members";
+import type { PostItem, Member, FeedItem } from "./types";
+
+function isValidUrl(str: string): boolean {
+  try {
+    const { protocol } = new URL(str);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+const parser = new Parser();
+let allPostItems: PostItem[] = [];
+
+async function fetchFeedItems(url: string) {
+  const feed = await parser.parseURL(url);
+  if (!feed?.items?.length) return [];
+
+  // return item which has title and link
+  return feed.items
+    .map(({ title, contentSnippet, link, isoDate }) => {
+      return {
+        title,
+        contentSnippet: contentSnippet?.replace(/\n/g, ""),
+        link,
+        isoDate,
+        dateMiliSeconds: isoDate ? new Date(isoDate).getTime() : 0,
+      };
+    })
+    .filter(({ title, link }) => title && link && isValidUrl(link)) as FeedItem[];
+}
+
+async function getFeedItemsFromSources(sources: undefined | string[]) {
+  if (!sources?.length) return [];
+  let feedItems: FeedItem[] = [];
+  for (const url of sources) {
+    const items = await fetchFeedItems(url);
+    if (items) feedItems = [...feedItems, ...items];
+  }
+  return feedItems;
+}
+
+async function getMemberFeedItems(member: Member): Promise<PostItem[]> {
+  const { id, sources, name, includeUrlRegex, excludeUrlRegex } = member;
+  const feedItems = await getFeedItemsFromSources(sources);
+  if (!feedItems) return [];
+
+  let postItems = feedItems.map((item) => {
+    return {
+      ...item,
+      authorName: name,
+      authorId: id,
+    };
+  });
+  // remove items which not matches includeUrlRegex
+  if (includeUrlRegex) {
+    postItems = postItems.filter((item) => {
+      return item.link.match(new RegExp(includeUrlRegex));
+    });
+  }
+  // remove items which matches excludeUrlRegex
+  if (excludeUrlRegex) {
+    postItems = postItems.filter((item) => {
+      return !item.link.match(new RegExp(excludeUrlRegex));
+    });
+  }
+
+  return postItems;
+}
+
+(async function () {
+  console.log("rss-feeds collecting script starts");
+  for (const member of members) {
+    const items = await getMemberFeedItems(member);
+    if (items) allPostItems = [...allPostItems, ...items];
+  }
+  allPostItems.sort((a, b) => b.dateMiliSeconds - a.dateMiliSeconds);
+  fs.ensureDirSync(".contents");
+  fs.writeJsonSync(".contents/posts.json", allPostItems);
+})();

--- a/src/feedsCollector/members.ts
+++ b/src/feedsCollector/members.ts
@@ -2,14 +2,14 @@ import type { Member } from "./types";
 
 export const members: Member[] = [
   {
-    id: "Yusuke Kominami",
-    name: "小南 佑介",
-    role: "代表社員",
-    bio: "2020年京都大学理学部卒業。同年ソフトバンク株式会社に入社し、フルスタックエンジニアとして開発に参画。2021年にヘイ株式会社（後にSTORES株式会社に商号変更）に入社し、1人目のデータエンジニアとしてデータ基盤を構築。",
-    avatarSrc: "/avatars/catnose.jpg",
-    sources: ["https://komi.dev/index.xml"],
-    twitterUsername: "@komi_edtr_1230",
-    githubUsername: "komi1230",
-    websiteUrl: "https://komi.dev",
+    id: "Ryuichi Umehara",
+    name: "梅原 隆一",
+    role: "業務委託メンバー",
+    bio: "京都大学情報学研究科M1",
+    avatarSrc: "https://pbs.twimg.com/profile_images/1307941138297311232/McTtMOUI_200x200.jpg",
+    sources: ["https://qiita.com/ryuichiastrona/feed"],
+    twitterUsername: "@astrona0626",
+    githubUsername: "umepon0626",
+    websiteUrl: "https://qiita.com/ryuichiastrona",
   },
 ];

--- a/src/feedsCollector/members.ts
+++ b/src/feedsCollector/members.ts
@@ -1,0 +1,15 @@
+import type { Member } from "./types";
+
+export const members: Member[] = [
+  {
+    id: "Yusuke Kominami",
+    name: "小南 佑介",
+    role: "代表社員",
+    bio: "2020年京都大学理学部卒業。同年ソフトバンク株式会社に入社し、フルスタックエンジニアとして開発に参画。2021年にヘイ株式会社（後にSTORES株式会社に商号変更）に入社し、1人目のデータエンジニアとしてデータ基盤を構築。",
+    avatarSrc: "/avatars/catnose.jpg",
+    sources: ["https://komi.dev/index.xml"],
+    twitterUsername: "@komi_edtr_1230",
+    githubUsername: "komi1230",
+    websiteUrl: "https://komi.dev",
+  },
+];

--- a/src/feedsCollector/types.ts
+++ b/src/feedsCollector/types.ts
@@ -1,0 +1,31 @@
+export type FeedItem = {
+  title: string;
+  link: string;
+  contentSnippet?: string;
+  isoDate?: string;
+  dateMiliSeconds: number;
+};
+
+export type Member = {
+  id: string;
+  name: string;
+  avatarSrc: string;
+  role?: string;
+  bio?: string;
+  sources?: string[];
+  includeUrlRegex?: string;
+  excludeUrlRegex?: string;
+  githubUsername?: string;
+  twitterUsername?: string;
+  websiteUrl?: string;
+};
+
+export type PostItem = {
+  authorId: string;
+  authorName: string;
+  title: string;
+  link: string;
+  contentSnippet?: string;
+  isoDate?: string;
+  dateMiliSeconds: number;
+};

--- a/tsconfig.feedsCollector.json
+++ b/tsconfig.feedsCollector.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+  },
+  "exclude": ["node_modules"],
+  "include": ["src/feedsCollector/*.ts"],
+  "ts-node": {
+    "esm": true,
+    "experimentalSpecifierResolution": "node"
+  }
+}

--- a/tsconfig.feedsCollector.json
+++ b/tsconfig.feedsCollector.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
+    "baseUrl": "./"
   },
   "exclude": ["node_modules"],
   "include": ["src/feedsCollector/*.ts"],


### PR DESCRIPTION
## What
- members.tsで登録されたメンバーのブログを収集してjsonで吐き出すスクリプトを https://github.com/catnose99/team-blog-hub から移植しました。
- related to #41 
- `pnpm run collect_rss`コマンドを実行することで以下のようなjsonファイルが`<project_root>/.contents/posts.json`に作成されます。

```json
[
  {
    "title": "顧客数と社内リソースのスケーリング",
    "contentSnippet": "ケイスクワッドの動きが多少変わってきた 3月になり、花粉症がひどくなってきた。 ずっと市販薬でなんとかしていたが、先日とうとう意を決して耳鼻科に",
    "link": "http://komi.dev/post/2023-03-17/",
    "isoDate": "2023-03-17T00:00:00.000Z",
    "dateMiliSeconds": 1679011200000,
    "authorName": "小南 佑介",
    "authorId": "Yusuke Kominami"
  },
  {
    "title": "システム屋の資金繰り",
    "contentSnippet": "会社として走り出した 2023年は頑張るぞと意気込みをまとめたエントリーを書いたのが1ヶ月前。 現状どうなっているかというと資金ショートギリギリ",
    "link": "http://komi.dev/post/2023-02-27-cash-flow/",
    "isoDate": "2023-02-27T00:00:00.000Z",
    "dateMiliSeconds": 1677456000000,
    "authorName": "小南 佑介",
    "authorId": "Yusuke Kominami"
  }
]
```

## TODO
- [x] scriptの移植
- [x] 動作確認


